### PR TITLE
Remove comma (,) from getopt string for option "debug="

### DIFF
--- a/src/sst/elements/ember/test/emberLoad.py
+++ b/src/sst/elements/ember/test/emberLoad.py
@@ -74,7 +74,7 @@ motifDefaults = {
 
 try:
     opts, args = getopt.getopt(sys.argv[1:], "", ["topo=", "shape=","hostsPerRtr=",
-                 "simConfig=","platParams=",",debug=","platform=","numNodes=",
+                 "simConfig=","platParams=","debug=","platform=","numNodes=",
                  "numCores=","loadFile=","loadFileVar=","cmdLine=","printStats=","randomPlacement=",
                  "emberVerbose=","netBW=","netPktSize=","netFlitSize=",
                  "rtrArb=","embermotifLog=","rankmapper=", "motifAPI=",


### PR DESCRIPTION
The additional comma (,) meant you could not call the "debug" modelOption of emberLoad.py with "--debug=1", as the option was not recognized because of the additional comma.